### PR TITLE
Prevention of validation error "schemaName is not allowed on oracle"

### DIFF
--- a/src/main/java/liquibase/ext/ora/createtrigger/CreateTriggerChange.java
+++ b/src/main/java/liquibase/ext/ora/createtrigger/CreateTriggerChange.java
@@ -207,7 +207,7 @@ public class CreateTriggerChange extends AbstractChange {
         }
 
 
-        CreateTriggerStatement statement = new CreateTriggerStatement(getSchemaName() == null ? database.getDefaultSchemaName() : getSchemaName(), getTriggerName(), getAfterBeforeInsteadOf());
+        CreateTriggerStatement statement = new CreateTriggerStatement(getSchemaName(), getTriggerName(), getAfterBeforeInsteadOf());
         statement.setTablespace(getTablespace());
         statement.setDelete(delete);
         statement.setInsert(insert);

--- a/src/main/java/liquibase/ext/ora/disabletrigger/DisableTriggerChange.java
+++ b/src/main/java/liquibase/ext/ora/disabletrigger/DisableTriggerChange.java
@@ -43,8 +43,7 @@ public class DisableTriggerChange extends AbstractChange {
     }
 
     public SqlStatement[] generateStatements(Database database) {
-        DisableTriggerStatement statement = new DisableTriggerStatement(getSchemaName() == null ? database
-                .getDefaultSchemaName() : getSchemaName(), getTriggerName());
+        DisableTriggerStatement statement = new DisableTriggerStatement(getSchemaName(), getTriggerName());
 
         return new SqlStatement[]{statement};
     }

--- a/src/main/java/liquibase/ext/ora/enabletrigger/EnableTriggerChange.java
+++ b/src/main/java/liquibase/ext/ora/enabletrigger/EnableTriggerChange.java
@@ -43,8 +43,7 @@ public class EnableTriggerChange extends AbstractChange {
     }
 
     public SqlStatement[] generateStatements(Database database) {
-        EnableTriggerStatement statement = new EnableTriggerStatement(getSchemaName() == null ? database
-                .getDefaultSchemaName() : getSchemaName(), getTriggerName());
+        EnableTriggerStatement statement = new EnableTriggerStatement(getSchemaName(), getTriggerName());
 
         return new SqlStatement[]{statement};
     }

--- a/src/main/java/liquibase/ext/ora/renametrigger/RenameTriggerChange.java
+++ b/src/main/java/liquibase/ext/ora/renametrigger/RenameTriggerChange.java
@@ -42,8 +42,7 @@ public class RenameTriggerChange extends AbstractChange {
     }
 
     public SqlStatement[] generateStatements(Database database) {
-        RenameTriggerStatement statement = new RenameTriggerStatement(getSchemaName() == null ? database
-                .getDefaultSchemaName() : getSchemaName(), getTriggerName(), getNewName());
+        RenameTriggerStatement statement = new RenameTriggerStatement(getSchemaName(), getTriggerName(), getNewName());
 
         return new SqlStatement[]{statement};
     }


### PR DESCRIPTION
Trigger functions do not work with Liquibase 3.1 and Liquibase-Oracle 3.0. createTrigger (also disableTrigger, renameTrigger and enableTrigger) do not work and give the validation error "schemaName is not allowed on oracle".

This is caused by the initialization of the schemaName member with the default database schema, if no schema name was provided in the XML. In my opinion, this can never work.
