### PR TITLE
Added Oracle synonym's support

### DIFF
--- a/src/main/java/liquibase/ext/ora/createSynonym/CreateSynonymChange.java
+++ b/src/main/java/liquibase/ext/ora/createSynonym/CreateSynonymChange.java
@@ -1,0 +1,100 @@
+package liquibase.ext.ora.createSynonym;
+
+import java.text.MessageFormat;
+
+import liquibase.change.AbstractChange;
+import liquibase.change.Change;
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.database.Database;
+import liquibase.ext.ora.dropSynonym.DropSynonymChange;
+import liquibase.statement.SqlStatement;
+
+@DatabaseChange(name = "createSynonym", description = "Create synonym", priority = ChangeMetaData.PRIORITY_DEFAULT)
+public class CreateSynonymChange extends AbstractChange {
+	
+	private boolean replace = false;
+	private boolean isPublic = false;
+	private String objectName;
+	private String objectSchemaName;
+
+	private String synonymName;
+	private String synonymSchemaName;
+
+	public boolean isReplace() {
+		return replace;
+	}
+
+	public void setReplace(boolean replace) {
+		this.replace = replace;
+	}
+
+	public boolean isPublic() {
+		return isPublic;
+	}
+
+	public void setPublic(boolean isPublic) {
+		this.isPublic = isPublic;
+	}
+
+	public String getObjectName() {
+		return objectName;
+	}
+
+	public void setObjectName(String objectName) {
+		this.objectName = objectName;
+	}
+
+	public String getObjectSchemaName() {
+		return objectSchemaName;
+	}
+
+	public void setObjectSchemaName(String objectSchemaName) {
+		this.objectSchemaName = objectSchemaName;
+	}
+
+	public String getSynonymName() {
+		return synonymName;
+	}
+
+	public void setSynonymName(String synonymName) {
+		this.synonymName = synonymName;
+	}
+
+	public String getSynonymSchemaName() {
+		return synonymSchemaName;
+	}
+
+	public void setSynonymSchemaName(String synonymSchemaName) {
+		this.synonymSchemaName = synonymSchemaName;
+	}
+
+    @Override
+    public String getConfirmationMessage() {
+        return MessageFormat.format("Synonym {0} created", getSynonymName());
+    }
+
+	@Override
+	protected Change[] createInverses() {
+		DropSynonymChange inverse = new DropSynonymChange();
+		inverse.setPublic(isPublic());
+		inverse.setSynonymName(getSynonymName());
+		inverse.setSynonymSchemaName(getSynonymSchemaName());
+		return new Change[] { inverse };
+	}
+	
+	@Override
+	public SqlStatement[] generateStatements(Database database) {
+		CreateSynonymStatement statement = new CreateSynonymStatement();
+
+		statement.setObjectName(getObjectName());
+		statement.setObjectSchemaName(getObjectSchemaName());
+		statement.setSynonymName(getSynonymName());
+		statement.setSynonymSchemaName(getSynonymSchemaName());
+
+		statement.setReplace(isReplace());
+		statement.setPublic(isPublic());
+		return new SqlStatement[] { statement };
+	}
+
+}

--- a/src/main/java/liquibase/ext/ora/createSynonym/CreateSynonymOracle.java
+++ b/src/main/java/liquibase/ext/ora/createSynonym/CreateSynonymOracle.java
@@ -1,0 +1,57 @@
+package liquibase.ext.ora.createSynonym;
+
+import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AbstractSqlGenerator;
+
+public class CreateSynonymOracle extends AbstractSqlGenerator<CreateSynonymStatement> {
+
+	public boolean supports(CreateSynonymStatement statement, Database database) {
+		return database instanceof OracleDatabase;
+	}
+
+	public ValidationErrors validate(CreateSynonymStatement statement, Database database, SqlGeneratorChain chain) {
+
+		ValidationErrors validationErrors = new ValidationErrors();
+		validationErrors.checkRequiredField("objectName", statement.getObjectName());
+		validationErrors.checkRequiredField("synonymName", statement.getSynonymName());
+		return validationErrors;
+	}
+
+	/**
+	 * CREATE [OR REPLACE] [PUBLIC] SYNONYM [schema.]synonym FOR
+	 * [schema.]object[@dblink] ;
+	 * 
+	 */
+	public Sql[] generateSql(CreateSynonymStatement statement, Database database, SqlGeneratorChain chain) {
+		StringBuilder sql = new StringBuilder("CREATE ");
+		if (statement.isReplace()) {
+			sql.append("OR REPLACE ");
+		}
+
+		if (statement.isPublic()) {
+			sql.append("PUBLIC ");
+		}
+
+		sql.append("SYNONYM ");
+
+		if (statement.getSynonymSchemaName() != null) {
+			sql.append(statement.getSynonymSchemaName()).append(".");
+		}
+
+		sql.append(statement.getSynonymName());
+		sql.append(" FOR ");
+
+		if (statement.getObjectSchemaName() != null) {
+			sql.append(statement.getObjectSchemaName()).append(".");
+		}
+
+		sql.append(statement.getObjectName());
+
+		return new Sql[] { new UnparsedSql(sql.toString()) };
+	}
+}

--- a/src/main/java/liquibase/ext/ora/createSynonym/CreateSynonymStatement.java
+++ b/src/main/java/liquibase/ext/ora/createSynonym/CreateSynonymStatement.java
@@ -1,0 +1,62 @@
+package liquibase.ext.ora.createSynonym;
+
+import liquibase.statement.AbstractSqlStatement;
+
+public class CreateSynonymStatement extends AbstractSqlStatement {
+	
+	private boolean replace = false;
+	private boolean isPublic = false;
+	private String objectName;
+	private String objectSchemaName;
+
+	private String synonymName;
+	private String synonymSchemaName;
+
+	public boolean isReplace() {
+		return replace;
+	}
+
+	public void setReplace(boolean replace) {
+		this.replace = replace;
+	}
+
+	public boolean isPublic() {
+		return isPublic;
+	}
+
+	public void setPublic(boolean isPublic) {
+		this.isPublic = isPublic;
+	}
+
+	public String getObjectName() {
+		return objectName;
+	}
+
+	public void setObjectName(String objectName) {
+		this.objectName = objectName;
+	}
+
+	public String getObjectSchemaName() {
+		return objectSchemaName;
+	}
+
+	public void setObjectSchemaName(String objectSchemaName) {
+		this.objectSchemaName = objectSchemaName;
+	}
+
+	public String getSynonymName() {
+		return synonymName;
+	}
+
+	public void setSynonymName(String synonymName) {
+		this.synonymName = synonymName;
+	}
+
+	public String getSynonymSchemaName() {
+		return synonymSchemaName;
+	}
+
+	public void setSynonymSchemaName(String synonymSchemaName) {
+		this.synonymSchemaName = synonymSchemaName;
+	}
+}

--- a/src/main/java/liquibase/ext/ora/dropSynonym/DropSynonymChange.java
+++ b/src/main/java/liquibase/ext/ora/dropSynonym/DropSynonymChange.java
@@ -1,0 +1,68 @@
+package liquibase.ext.ora.dropSynonym;
+
+import java.text.MessageFormat;
+
+import liquibase.change.AbstractChange;
+import liquibase.change.Change;
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.database.Database;
+import liquibase.ext.ora.dropcheck.DropCheckChange;
+import liquibase.statement.SqlStatement;
+
+@DatabaseChange(name = "dropSynonym", description = "Drop synonym", priority = ChangeMetaData.PRIORITY_DEFAULT)
+public class DropSynonymChange extends AbstractChange {
+
+	private boolean isPublic = false;
+	private String synonymSchemaName;
+	private String synonymName;
+	private boolean force = false;
+
+	public boolean isPublic() {
+		return isPublic;
+	}
+
+	public void setPublic(boolean isPublic) {
+		this.isPublic = isPublic;
+	}
+
+	public String getSynonymName() {
+		return synonymName;
+	}
+
+	public void setSynonymName(String synonymName) {
+		this.synonymName = synonymName;
+	}
+
+	public String getSynonymSchemaName() {
+		return synonymSchemaName;
+	}
+
+	public void setSynonymSchemaName(String synonymSchemaName) {
+		this.synonymSchemaName = synonymSchemaName;
+	}
+
+	public boolean isForce() {
+		return force;
+	}
+
+	public void setForce(boolean force) {
+		this.force = force;
+	}
+
+    @Override
+    public String getConfirmationMessage() {
+        return MessageFormat.format("Synonym {0} dropped", getSynonymName());
+    }
+
+	@Override
+	public SqlStatement[] generateStatements(Database database) {
+		DropSynonymStatement statement = new DropSynonymStatement();
+		statement.setForce(isForce());
+		statement.setSynonymName(getSynonymName());
+		statement.setSynonymSchemaName(getSynonymSchemaName());
+		statement.setPublic(isPublic());
+		return new SqlStatement[] { statement };
+	}
+
+}

--- a/src/main/java/liquibase/ext/ora/dropSynonym/DropSynonymOracle.java
+++ b/src/main/java/liquibase/ext/ora/dropSynonym/DropSynonymOracle.java
@@ -1,0 +1,48 @@
+package liquibase.ext.ora.dropSynonym;
+
+import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AbstractSqlGenerator;
+
+public class DropSynonymOracle extends AbstractSqlGenerator<DropSynonymStatement> {
+
+	public boolean supports(DropSynonymStatement statement, Database database) {
+		return database instanceof OracleDatabase;
+	}
+
+	public ValidationErrors validate(DropSynonymStatement statement, Database database, SqlGeneratorChain chain) {
+
+		ValidationErrors validationErrors = new ValidationErrors();
+		validationErrors.checkRequiredField("synonymName", statement.getSynonymName());
+		return validationErrors;
+	}
+
+	/**
+	 * DROP [PUBLIC] SYNONYM [ schema. ] synonym [FORCE] ;
+	 */
+	public Sql[] generateSql(DropSynonymStatement statement, Database database, SqlGeneratorChain chain) {
+		StringBuilder sql = new StringBuilder("DROP ");
+
+		if (statement.isPublic()) {
+			sql.append("PUBLIC ");
+		}
+
+		sql.append("SYNONYM ");
+
+		if (statement.getSynonymSchemaName() != null) {
+			sql.append(statement.getSynonymSchemaName()).append(".");
+		}
+
+		sql.append(statement.getSynonymName());
+
+		if (statement.isForce()) {
+			sql.append(" FORCE");
+		}
+
+		return new Sql[] { new UnparsedSql(sql.toString()) };
+	}
+}

--- a/src/main/java/liquibase/ext/ora/dropSynonym/DropSynonymStatement.java
+++ b/src/main/java/liquibase/ext/ora/dropSynonym/DropSynonymStatement.java
@@ -1,0 +1,42 @@
+package liquibase.ext.ora.dropSynonym;
+
+import liquibase.statement.AbstractSqlStatement;
+
+public class DropSynonymStatement extends AbstractSqlStatement {
+	private boolean isPublic = false;
+	private boolean force = false;
+	private String synonymName;
+	private String synonymSchemaName;
+
+	public boolean isPublic() {
+		return isPublic;
+	}
+
+	public void setPublic(boolean isPublic) {
+		this.isPublic = isPublic;
+	}
+
+	public String getSynonymName() {
+		return synonymName;
+	}
+
+	public void setSynonymName(String synonymName) {
+		this.synonymName = synonymName;
+	}
+
+	public String getSynonymSchemaName() {
+		return synonymSchemaName;
+	}
+
+	public void setSynonymSchemaName(String synonymSchemaName) {
+		this.synonymSchemaName = synonymSchemaName;
+	}
+
+	public boolean isForce() {
+		return force;
+	}
+
+	public void setForce(boolean force) {
+		this.force = force;
+	}
+}

--- a/src/main/java/liquibase/ext/ora/xml/dbchangelog-ext.xsd
+++ b/src/main/java/liquibase/ext/ora/xml/dbchangelog-ext.xsd
@@ -250,4 +250,25 @@
         </xsd:complexType>
     </xsd:element>
 
+	<!-- Create synonym -->
+    <xsd:element name="createSynonym">
+        <xsd:complexType>
+            <xsd:attribute name="public" type="xsd:boolean"/>
+            <xsd:attribute name="replace" type="xsd:boolean"/>
+            <xsd:attribute name="synonymSchemaName" type="xsd:string"/>
+            <xsd:attribute name="synonymName" type="xsd:string"/>
+            <xsd:attribute name="objectSchemaName" type="xsd:string"/>
+            <xsd:attribute name="objectName" type="xsd:string" />
+        </xsd:complexType>
+    </xsd:element>
+
+	<!-- Drop synonym -->
+	<xsd:element name="dropSynonym">
+        <xsd:complexType>
+            <xsd:attribute name="public" type="xsd:boolean"/>
+            <xsd:attribute name="force" type="xsd:boolean"/>
+            <xsd:attribute name="synonymSchemaName" type="xsd:string"/>
+            <xsd:attribute name="synonymName" type="xsd:string"/>
+        </xsd:complexType>
+    </xsd:element>
 </xsd:schema>

--- a/src/test/java/liquibase/ext/ora/synonym/BaseSynonymTest.java
+++ b/src/test/java/liquibase/ext/ora/synonym/BaseSynonymTest.java
@@ -1,0 +1,18 @@
+package liquibase.ext.ora.synonym;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import liquibase.exception.DatabaseException;
+import liquibase.ext.ora.testing.BaseTestCase;
+
+public abstract class BaseSynonymTest extends BaseTestCase {
+	private static final String SYNONYM_CHECK = "SELECT synonym_name FROM user_synonyms "
+			+ "WHERE synonym_name = 'NEW_SYNONYM'";
+
+	protected boolean synonymExists() throws SQLException, DatabaseException {
+		ResultSet result = jdbcConnection.createStatement().executeQuery(SYNONYM_CHECK);
+		return result.next();
+	}
+
+}

--- a/src/test/java/liquibase/ext/ora/synonym/createSynonym/CreateSynonymDbTest.java
+++ b/src/test/java/liquibase/ext/ora/synonym/createSynonym/CreateSynonymDbTest.java
@@ -1,0 +1,30 @@
+package liquibase.ext.ora.synonym.createSynonym;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import liquibase.ext.ora.synonym.BaseSynonymTest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class CreateSynonymDbTest extends BaseSynonymTest {
+
+	@Before
+	public void setUp() throws Exception {
+		changeLogFile = "liquibase/ext/ora/synonym/createSynonym/changelog.text.xml";
+		connectToDB();
+		cleanDB();
+	}
+
+	@Test
+	public void testCompare() throws Exception {
+		assertFalse(synonymExists());
+
+		liquiBase.update(null);
+		assertTrue(synonymExists());
+
+		liquiBase.rollback(1, null);
+		assertFalse(synonymExists());
+	}
+
+}

--- a/src/test/java/liquibase/ext/ora/synonym/createSynonym/CreateSynonymTest.java
+++ b/src/test/java/liquibase/ext/ora/synonym/createSynonym/CreateSynonymTest.java
@@ -1,0 +1,113 @@
+package liquibase.ext.ora.synonym.createSynonym;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import liquibase.change.Change;
+import liquibase.change.ChangeFactory;
+import liquibase.change.ChangeMetaData;
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
+import liquibase.ext.ora.createSynonym.CreateSynonymChange;
+import liquibase.ext.ora.createSynonym.CreateSynonymStatement;
+import liquibase.ext.ora.testing.BaseTestCase;
+import liquibase.parser.ChangeLogParserFactory;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.ResourceAccessor;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.statement.SqlStatement;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class CreateSynonymTest extends BaseTestCase {
+	private static final String OBJECT_SCHEMA = "object_schema";
+	private static final String OBJECT_NAME = "object";
+	private static final String SYNONYM_NAME = "synonym_name";
+	private static final String SYNONYM_SCHEMA = "synonym_schema";
+
+	@Before
+	public void setUp() throws Exception {
+		changeLogFile = "liquibase/ext/ora/synonym/createSynonym/changelog.text.xml";
+		connectToDB();
+		cleanDB();
+	}
+
+	@Test
+	public void getChangeMetaData() {
+		CreateSynonymChange createSynonymChange = new CreateSynonymChange();
+		assertEquals("createSynonym", ChangeFactory.getInstance().getChangeMetaData(createSynonymChange).getName());
+		assertEquals("Create synonym", ChangeFactory.getInstance().getChangeMetaData(createSynonymChange).getDescription());
+		assertEquals(ChangeMetaData.PRIORITY_DEFAULT, ChangeFactory.getInstance().getChangeMetaData(createSynonymChange).getPriority());
+	}
+
+	@Test
+	public void getConfirmationMessage() {
+		CreateSynonymChange change = new CreateSynonymChange();
+		change.setSynonymName("new_synonym");
+		assertEquals("Synonym new_synonym created", change.getConfirmationMessage());
+	}
+
+	@Test
+	public void generateStatement() {
+
+		CreateSynonymChange change = new CreateSynonymChange();
+		change.setReplace(true);
+		change.setPublic(true);
+
+		change.setSynonymSchemaName(SYNONYM_SCHEMA);
+		change.setSynonymName(SYNONYM_NAME);
+		change.setObjectSchemaName(OBJECT_SCHEMA);
+		change.setObjectName(OBJECT_NAME);
+
+		Database database = new OracleDatabase();
+		SqlStatement[] sqlStatements = change.generateStatements(database);
+
+		assertEquals(1, sqlStatements.length);
+		assertTrue(sqlStatements[0] instanceof CreateSynonymStatement);
+
+		CreateSynonymStatement statement = (CreateSynonymStatement) sqlStatements[0];
+
+		assertTrue(statement.isReplace());
+		assertTrue(statement.isPublic());
+
+		assertEquals(OBJECT_NAME, statement.getObjectName());
+		assertEquals(OBJECT_SCHEMA, statement.getObjectSchemaName());
+
+		assertEquals(SYNONYM_NAME, statement.getSynonymName());
+		assertEquals(SYNONYM_SCHEMA, statement.getSynonymSchemaName());
+	}
+
+	@Test
+	public void parseAndGenerate() throws Exception {
+		Database database = liquiBase.getDatabase();
+		ResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor();
+
+		ChangeLogParameters changeLogParameters = new ChangeLogParameters();
+
+		DatabaseChangeLog changeLog = ChangeLogParserFactory.getInstance().getParser(changeLogFile, resourceAccessor).parse(changeLogFile,
+				changeLogParameters, resourceAccessor);
+
+		database.checkDatabaseChangeLogTable(false, changeLog);
+		changeLog.validate(database);
+
+		List<ChangeSet> changeSets = changeLog.getChangeSets();
+		Change change = changeSets.get(0).getChanges().get(0);
+		Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(change.generateStatements(database)[0], database);
+
+		String expected = "CREATE SYNONYM new_synonym FOR object";
+		assertEquals(expected, sql[0].toSql());
+	}
+
+	@Test
+	public void test() throws Exception {
+		liquiBase.update(null);
+		liquiBase.rollback(1, null);
+	}
+}

--- a/src/test/java/liquibase/ext/ora/synonym/createSynonym/changelog.text.xml
+++ b/src/test/java/liquibase/ext/ora/synonym/createSynonym/changelog.text.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ora="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog ../../../../../java/liquibase/ext/ora/xml/dbchangelog-2.0.xsd 
+        http://www.liquibase.org/xml/ns/dbchangelog-ext ../../../../../java/liquibase/ext/ora/xml/dbchangelog-ext.xsd ">
+
+	<changeSet id="Create synonym new_synonym for object" author="Ivan">
+		<ora:createSynonym objectName="object" synonymName="new_synonym" />
+	</changeSet>
+</databaseChangeLog>

--- a/src/test/java/liquibase/ext/ora/synonym/dropSynonym/DropSynonymDbTest.java
+++ b/src/test/java/liquibase/ext/ora/synonym/dropSynonym/DropSynonymDbTest.java
@@ -1,0 +1,34 @@
+package liquibase.ext.ora.synonym.dropSynonym;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import liquibase.exception.DatabaseException;
+import liquibase.ext.ora.synonym.BaseSynonymTest;
+import liquibase.ext.ora.testing.BaseTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DropSynonymDbTest extends BaseSynonymTest {
+
+	@Before
+	public void setUp() throws Exception {
+		changeLogFile = "liquibase/ext/ora/synonym/dropSynonym/changelog.text.xml";
+		connectToDB();
+		cleanDB();
+	}
+
+	@Test
+	public void testCompare() throws Exception {
+		jdbcConnection.createStatement().executeQuery("CREATE OR REPLACE SYNONYM new_synonym FOR object");
+		assertTrue(synonymExists());
+
+		liquiBase.update(null);
+		assertFalse(synonymExists());
+
+	}
+}

--- a/src/test/java/liquibase/ext/ora/synonym/dropSynonym/DropSynonymTest.java
+++ b/src/test/java/liquibase/ext/ora/synonym/dropSynonym/DropSynonymTest.java
@@ -1,0 +1,98 @@
+package liquibase.ext.ora.synonym.dropSynonym;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import liquibase.change.Change;
+import liquibase.change.ChangeFactory;
+import liquibase.change.ChangeMetaData;
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
+import liquibase.ext.ora.dropSynonym.DropSynonymChange;
+import liquibase.ext.ora.dropSynonym.DropSynonymStatement;
+import liquibase.ext.ora.testing.BaseTestCase;
+import liquibase.parser.ChangeLogParserFactory;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.ResourceAccessor;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.statement.SqlStatement;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DropSynonymTest extends BaseTestCase {
+	private static final String SYNONYM_NAME = "synonym_name";
+	private static final String SYNONYM_SCHEMA = "synonym_schema";
+
+	@Before
+	public void setUp() throws Exception {
+		changeLogFile = "liquibase/ext/ora/synonym/dropSynonym/changelog.text.xml";
+		connectToDB();
+		cleanDB();
+	}
+
+	@Test
+	public void getChangeMetaData() {
+		DropSynonymChange change = new DropSynonymChange();
+		assertEquals("dropSynonym", ChangeFactory.getInstance().getChangeMetaData(change).getName());
+		assertEquals("Drop synonym", ChangeFactory.getInstance().getChangeMetaData(change).getDescription());
+		assertEquals(ChangeMetaData.PRIORITY_DEFAULT, ChangeFactory.getInstance().getChangeMetaData(change).getPriority());
+	}
+
+	@Test
+	public void getConfirmationMessage() {
+		DropSynonymChange change = new DropSynonymChange();
+		change.setSynonymName("new_synonym");
+		assertEquals("Synonym new_synonym dropped", change.getConfirmationMessage());
+	}
+
+	@Test
+	public void generateStatement() {
+		DropSynonymChange change = new DropSynonymChange();
+
+		change.setPublic(true);
+		change.setSynonymSchemaName(SYNONYM_SCHEMA);
+		change.setSynonymName(SYNONYM_NAME);
+		change.setForce(true);
+
+		Database database = new OracleDatabase();
+		SqlStatement[] sqlStatements = change.generateStatements(database);
+
+		assertEquals(1, sqlStatements.length);
+		assertTrue(sqlStatements[0] instanceof DropSynonymStatement);
+
+		DropSynonymStatement statement = (DropSynonymStatement) sqlStatements[0];
+
+		assertTrue(statement.isForce());
+		assertTrue(statement.isPublic());
+		assertEquals(SYNONYM_NAME, statement.getSynonymName());
+		assertEquals(SYNONYM_SCHEMA, statement.getSynonymSchemaName());
+	}
+
+	@Test
+	public void parseAndGenerate() throws Exception {
+		Database database = liquiBase.getDatabase();
+		ResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor();
+
+		ChangeLogParameters changeLogParameters = new ChangeLogParameters();
+
+		DatabaseChangeLog changeLog = ChangeLogParserFactory.getInstance().getParser(changeLogFile, resourceAccessor).parse(changeLogFile,
+				changeLogParameters, resourceAccessor);
+
+		database.checkDatabaseChangeLogTable(false, changeLog);
+		changeLog.validate(database);
+
+		List<ChangeSet> changeSets = changeLog.getChangeSets();
+		Change change = changeSets.get(0).getChanges().get(0);
+		Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(change.generateStatements(database)[0], database);
+
+		String expected = "DROP SYNONYM new_synonym";
+		assertEquals(expected, sql[0].toSql());
+	}
+}

--- a/src/test/java/liquibase/ext/ora/synonym/dropSynonym/changelog.text.xml
+++ b/src/test/java/liquibase/ext/ora/synonym/dropSynonym/changelog.text.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ora="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog ../../../../../java/liquibase/ext/ora/xml/dbchangelog-2.0.xsd 
+        http://www.liquibase.org/xml/ns/dbchangelog-ext ../../../../../java/liquibase/ext/ora/xml/dbchangelog-ext.xsd ">
+
+	<changeSet id="Drop synonym new_synonym" author="Ivan">
+		<ora:dropSynonym synonymName="new_synonym" />
+	</changeSet>
+</databaseChangeLog>

--- a/src/test/resources/tests.properties
+++ b/src/test/resources/tests.properties
@@ -7,6 +7,7 @@
 #   create trigger,
 #   create view,
 #   create any materialized view,
+#   create any synonym
 #   to liquibase;
 #
 # connect / as sysdba;


### PR DESCRIPTION
Implemented support of oracle synonyms. Now they can be created and deletedby this way:

``` xml
<changeSet id="Create synonym new_synonym" author="Ivan">
    <ora:createSynonym objectName="object" synonymName="new_synonym" />
</changeSet>
<changeSet id="Drop synonym new_synonym" author="Ivan">
    <ora:dropSynonym synonymName="new_synonym" />
</changeSet>
```
