### PR TITLE
Add  "COMMENT ON TABLE/COLUMN"

### DIFF
--- a/src/main/java/liquibase/ext/ora/comment/CommentOnChange.java
+++ b/src/main/java/liquibase/ext/ora/comment/CommentOnChange.java
@@ -1,0 +1,71 @@
+package liquibase.ext.ora.comment;
+
+import liquibase.change.AbstractChange;
+import liquibase.change.Change;
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.database.Database;
+import liquibase.statement.SqlStatement;
+
+
+@DatabaseChange(name="commentOn", description = "Create or replace a comment on a table or a column", priority = ChangeMetaData.PRIORITY_DEFAULT)
+public class CommentOnChange extends AbstractChange {
+
+    private String schemaName;
+    private String tableName;
+    private String columnName;
+    private String comment;
+
+    public CommentOnChange() {
+    }
+
+    public SqlStatement[] generateStatements(Database database) {
+
+        String schemaName = getSchemaName() == null ? database.getDefaultSchemaName() : getSchemaName();
+        CommentOnStatement statement = new CommentOnStatement(schemaName, getTableName(), getColumnName(), getComment() );
+        return new SqlStatement[]{statement};
+    }
+
+    public String getConfirmationMessage() {
+        return columnName == null
+                ? "Comment has been added to " + getTableName()
+                : "Comment has been added to " + getTableName() + "." + getColumnName();
+    }
+
+    // Since "COMMENT ON" replaces the existing comment is is not good to remove it as we don;t know what the last one was.
+    protected Change[] createInverses() {
+        return new Change[]{};
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public void setSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public void setColumnName(String columnName) {
+        this.columnName = columnName;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+}

--- a/src/main/java/liquibase/ext/ora/comment/CommentOnGenerator.java
+++ b/src/main/java/liquibase/ext/ora/comment/CommentOnGenerator.java
@@ -1,0 +1,39 @@
+package liquibase.ext.ora.comment;
+
+import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AbstractSqlGenerator;
+
+public class CommentOnGenerator extends AbstractSqlGenerator<CommentOnStatement> {
+
+
+    public Sql[] generateSql(CommentOnStatement statement, Database database,
+                             SqlGeneratorChain sqlGeneratorChain) {
+
+        String comment = database.escapeStringForDatabase(statement.getComment());
+        String tableName = database.escapeTableName(null, statement.getSchemaName(), statement.getTableName());
+        String columnName = database.escapeColumnName(null, statement.getSchemaName(), statement.getTableName(), statement.getColumnName());
+
+        String sql = statement.isColumnComment()
+                ? String.format("COMMENT ON COLUMN %s.%s IS '%s'", tableName, columnName, comment)
+                : String.format("COMMENT ON TABLE %s IS '%s'", tableName, comment);
+        return new Sql[]{new UnparsedSql(sql)};
+    }
+
+    public boolean supports(CommentOnStatement statement, Database database) {
+        return database instanceof OracleDatabase;
+    }
+
+    public ValidationErrors validate(CommentOnStatement statement,
+                                     Database database, SqlGeneratorChain sqlGeneratorChain) {
+        ValidationErrors validationErrors = new ValidationErrors();
+        validationErrors.checkRequiredField("tableName", statement.getTableName());
+        validationErrors.checkRequiredField("comment", statement.getComment());
+        return validationErrors;
+    }
+
+}

--- a/src/main/java/liquibase/ext/ora/comment/CommentOnStatement.java
+++ b/src/main/java/liquibase/ext/ora/comment/CommentOnStatement.java
@@ -1,0 +1,50 @@
+package liquibase.ext.ora.comment;
+
+import liquibase.ext.ora.check.CheckState;
+import liquibase.statement.AbstractSqlStatement;
+import liquibase.statement.SqlStatement;
+
+public class CommentOnStatement extends AbstractSqlStatement implements SqlStatement {
+
+    private String schemaName;
+    private String tableName;
+    private String columnName;
+    private String comment;
+
+    public CommentOnStatement(String schemaName, String tableName, String columnName, String comment) {
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.columnName = columnName;
+        this.comment = comment;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public void setSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public boolean isColumnComment() {
+        return columnName != null;
+    }
+
+}

--- a/src/main/java/liquibase/ext/ora/xml/dbchangelog-ext.xsd
+++ b/src/main/java/liquibase/ext/ora/xml/dbchangelog-ext.xsd
@@ -311,4 +311,19 @@
             <xsd:attribute name="synonymName" type="xsd:string"/>
         </xsd:complexType>
     </xsd:element>
+
+    <xsd:attributeGroup name="tableLogicalAttribute">
+        <xsd:attribute name="schemaName" type="xsd:string"/>
+        <xsd:attribute name="tableName" type="xsd:string" use="required"/>
+    </xsd:attributeGroup>
+
+    <xsd:element name="commentOn">
+        <xsd:complexType>
+            <xsd:attributeGroup ref="tableLogicalAttribute"/>
+            <xsd:attribute name="columnName" type="xsd:string"/>
+            <xsd:attribute name="comment" type="xsd:string"/>
+        </xsd:complexType>
+    </xsd:element>
+
+
 </xsd:schema>

--- a/src/test/java/liquibase/ext/ora/comment/CommentOnChangeTest.java
+++ b/src/test/java/liquibase/ext/ora/comment/CommentOnChangeTest.java
@@ -1,0 +1,122 @@
+package liquibase.ext.ora.comment;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import liquibase.change.Change;
+import liquibase.change.ChangeFactory;
+import liquibase.change.ChangeMetaData;
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
+import liquibase.ext.ora.testing.BaseTestCase;
+import liquibase.parser.ChangeLogParserFactory;
+import liquibase.resource.FileSystemResourceAccessor;
+import liquibase.resource.ResourceAccessor;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.statement.SqlStatement;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommentOnChangeTest extends BaseTestCase {
+    @Before
+    public void setUp() throws Exception {
+        changeLogFile = "liquibase/ext/ora/comment/changelog.test.xml";
+        connectToDB();
+        cleanDB();
+    }
+
+    @Test
+    public void test() throws Exception {
+        if (connection == null) {
+            return;
+        }
+        liquiBase.update("null");
+
+    }
+
+    @Test
+    public void generateStatement() {
+        CommentOnChange change = new CommentOnChange();
+
+        change.setSchemaName("SCHEMA NAME");
+        change.setTableName("TABLE NAME");
+        change.setColumnName("COLUMN NAME");
+        change.setComment("My comment with 'quotes'");
+
+        SqlStatement[] statements = change.generateStatements(new OracleDatabase());
+        assertEquals(1, statements.length);
+        CommentOnStatement statement = (CommentOnStatement) statements[0];
+
+        assertEquals("SCHEMA NAME", statement.getSchemaName());
+        assertEquals("TABLE NAME", statement.getTableName());
+        assertEquals("COLUMN NAME", statement.getColumnName());
+        assertEquals("My comment with 'quotes'", statement.getComment());
+    }
+
+    @Test
+    public void getConfirmationMessage() {
+        CommentOnChange change = new CommentOnChange();
+
+        change.setTableName("TABLE_NAME");
+        change.setComment("COMMENT");
+
+        assertEquals("Comment has been added to " + change.getTableName(), change.getConfirmationMessage());
+    }
+
+    @Test
+    public void getChangeMetaData() {
+        CommentOnChange enableCheckChange = new CommentOnChange();
+
+        assertEquals("commentOn", ChangeFactory.getInstance().getChangeMetaData(enableCheckChange).getName());
+        assertEquals("Create or replace a comment on a table or a column", ChangeFactory.getInstance().getChangeMetaData(enableCheckChange).getDescription());
+        assertEquals(ChangeMetaData.PRIORITY_DEFAULT, ChangeFactory.getInstance().getChangeMetaData(enableCheckChange).getPriority());
+    }
+
+    @Test
+    public void parseAndGenerate() throws Exception {
+        if (connection == null) {
+            return;
+        }
+
+        Database database = liquiBase.getDatabase();
+        ResourceAccessor resourceAccessor = new FileSystemResourceAccessor("src/test/java");
+
+        ChangeLogParameters changeLogParameters = new ChangeLogParameters();
+
+
+        DatabaseChangeLog changeLog = ChangeLogParserFactory.getInstance().getParser(changeLogFile, resourceAccessor).parse(changeLogFile,
+                changeLogParameters, resourceAccessor);
+
+        changeLog.validate(database);
+        List<ChangeSet> changeSets = changeLog.getChangeSets();
+
+        assertExpectedQuery( changeFrom( changeSets, "column-comment"), "COMMENT ON COLUMN LBUSER.for_comment.id IS 'My comment ''quoted'''" );
+        assertExpectedQuery( changeFrom( changeSets, "table-comment"), "COMMENT ON TABLE LBUSER.for_comment IS 'My TABLE comment ''quoted'''" );
+        assertExpectedQuery( changeFrom( changeSets, "view-comment"), "COMMENT ON TABLE LBUSER.for_comment_view IS 'My VIEW comment'" );
+    }
+
+    private void assertExpectedQuery(Change change, String expectedSql) {
+        Database database = liquiBase.getDatabase();
+        Sql[] sqlStatements = SqlGeneratorFactory.getInstance().generateSql(change.generateStatements(database)[0], database);
+        assertEquals(1, sqlStatements.length);
+        assertEquals(expectedSql, sqlStatements[0].toSql());
+    }
+
+    private Change changeFrom(List<ChangeSet> changeSets, String changeSetId) {
+        for (ChangeSet changeSet : changeSets) {
+            if ( changeSetId.equals(changeSet.getId())){
+                List<Change> changes = changeSet.getChanges();
+                assertEquals(1, changes.size());
+                return changes.get(0);
+            }
+        }
+        throw new IllegalStateException("No change set with id " + changeSetId + " found");
+    }
+
+}

--- a/src/test/java/liquibase/ext/ora/comment/CommentOnDBTest.java
+++ b/src/test/java/liquibase/ext/ora/comment/CommentOnDBTest.java
@@ -1,0 +1,51 @@
+package liquibase.ext.ora.comment;
+
+import org.dbunit.Assertion;
+import org.dbunit.database.DatabaseConnection;
+import org.dbunit.database.IDatabaseConnection;
+import org.dbunit.database.QueryDataSet;
+import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.xml.FlatXmlDataSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import liquibase.ext.ora.testing.BaseTestCase;
+
+public class CommentOnDBTest extends BaseTestCase {
+
+    private IDataSet loadedDataSet;
+    private final String TABLE_NAME = "FOR_COMMENT";
+
+    protected IDatabaseConnection getConnection() throws Exception {
+        return new DatabaseConnection(connection);
+    }
+
+    protected IDataSet getDataSet() throws Exception {
+        loadedDataSet = new FlatXmlDataSet(this.getClass().getClassLoader().getResourceAsStream(
+                "liquibase/ext/ora/comment/input.xml"));
+        return loadedDataSet;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        changeLogFile = "liquibase/ext/ora/comment/changelog.test.xml";
+        connectToDB();
+        cleanDB();
+    }
+
+    @Test
+    public void testCompare() throws Exception {
+        if (connection == null) {
+            return;
+        }
+
+        QueryDataSet actualDataSet = new QueryDataSet(getConnection());
+
+        liquiBase.update((String) null);
+        actualDataSet.addTable("USER_COL_COMMENTS", "SELECT * FROM USER_COL_COMMENTS where TABLE_NAME='" + TABLE_NAME + "' and comments is not null");
+        actualDataSet.addTable("USER_TAB_COMMENTS", "SELECT * FROM USER_TAB_COMMENTS where TABLE_NAME='" + TABLE_NAME + "' and comments is not null");
+        loadedDataSet = getDataSet();
+
+        Assertion.assertEquals(loadedDataSet, actualDataSet);
+    }
+}

--- a/src/test/java/liquibase/ext/ora/comment/changelog.test.xml
+++ b/src/test/java/liquibase/ext/ora/comment/changelog.test.xml
@@ -1,0 +1,33 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:ora="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="table for comment" author="mjeffrey">
+        <createTable tableName="for_comment">
+            <column name="id" type="integer"/>
+            <column name="name" type="varchar2(50)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="view for comment" author="mjeffrey">
+        <createView viewName="for_comment_view" replaceIfExists="true">
+            select * from for_comment
+        </createView>
+    </changeSet>
+
+    <changeSet id="column-comment" author="mjeffrey">
+        <ora:commentOn tableName="for_comment" columnName="id" comment="My comment 'quoted'" />
+    </changeSet>
+
+    <changeSet id="table-comment" author="mjeffrey">
+        <ora:commentOn tableName="for_comment" comment="My TABLE comment 'quoted'" />
+    </changeSet>
+
+    <changeSet id="view-comment" author="mjeffrey">
+        <ora:commentOn tableName="for_comment_view" comment="My VIEW comment" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/liquibase/ext/ora/comment/input.xml
+++ b/src/test/java/liquibase/ext/ora/comment/input.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <USER_COL_COMMENTS TABLE_NAME="FOR_COMMENT" COLUMN_NAME="ID" COMMENTS="My comment 'quoted'" />
+    <USER_TAB_COMMENTS TABLE_NAME="FOR_COMMENT" TABLE_TYPE="TABLE" COMMENTS="My TABLE comment 'quoted'" />
+</dataset>


### PR DESCRIPTION
This change adds the ability to add comments to columns, tables and views independently of the object creation. It is useful to have changesets with runOnChange with all the documentation for the tables together. These changesets can always be executed since the comment is replaced.
