### PR TITLE
chore(workflows): update liquibase/build-logic workflows to v0.5.9

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.8
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.9
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     nightly-build:
-      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.8
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.9
       with:
         nightly: true
         os: '["ubuntu-latest"]'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   codeql:
-    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.5.8
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.5.9
     secrets: inherit
     with:
       languages: '["java"]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.8
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.9
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.8
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.9
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
   build-test:
     needs: authorize
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.8
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.9
     with:
       os: '["ubuntu-latest"]'
     secrets: inherit
@@ -42,5 +42,5 @@ jobs:
 
   dependabot:
     needs: build-test
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.8
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.9
     secrets: inherit


### PR DESCRIPTION
The liquibase/build-logic workflows have been updated to version v0.5.9. This update includes bug fixes and improvements to the workflows. By updating to the latest version, we ensure that we are using the most stable and up-to-date version of the workflows.