### PR TITLE
Add license to pom.xml and fix formatting of pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-	<parent>
+    <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent-pom</artifactId>
         <version>0.3.4</version> 
@@ -15,18 +15,24 @@
     <name>Liquibase Oracle Extensions</name>
     <description>Some tags to work on Oracle DB.</description>
     <url>http://liquibase.jira.com/wiki/display/CONTRIB/Oracle+Extensions</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
 
     <properties>
-		<liquibase.version>4.25.1</liquibase.version>
+        <liquibase.version>4.25.1</liquibase.version>
         <junit.version>4.13.2</junit.version>
     </properties>
 
-	<scm>
-	        <connection>scm:git:${project.scm.url}</connection>
-	        <developerConnection>scm:git:${project.scm.url}</developerConnection>
-		<url>https://github.com/liquibase/liquibase-oracle.git</url>
-		<tag>HEAD</tag>
-	</scm>
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+        <url>https://github.com/liquibase/liquibase-oracle.git</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <dependencies>
         <dependency>
@@ -47,17 +53,17 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>oracle-xe</artifactId>
-			<version>1.19.3</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-xe</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 
-	<build>
-		<plugins>
+    <build>
+        <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <dependencies>
@@ -72,8 +78,8 @@
                 </configuration>
             </plugin>
 
-		</plugins>
+        </plugins>
 
-	</build>
+    </build>
 
 </project>


### PR DESCRIPTION
The Apache 2.0 license info is missing in the pom.xml file - this PR adds the license info.

Also, the pom.xml had a mix of spaces and tabs - I fixed the formatting.