### PR TITLE
DAT-20199   DevOps :: Evaluate GitHub Actions arm64 Hosted Runners in Public Repositories

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@DAT-20199
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   nightly-build:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@DAT-20199
     with:
       nightly: true
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   codeql:
-    uses: liquibase/build-logic/.github/workflows/codeql.yml@main
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@DAT-20199
     secrets: inherit
     with:
       languages: '["java"]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@main
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@DAT-20199
     secrets: inherit

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   dry-run-attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@DAT-20199
     secrets: inherit
     with:
       dry_run: true
@@ -22,7 +22,7 @@ jobs:
 
   dry-run-get-draft-release:
     needs: dry-run-attach-artifact-to-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     outputs:
       dry_run_release_id: ${{ steps.get_draft_release_id.outputs.release_id }}
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   dry-run-release-published:
     needs: dry-run-get-draft-release
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@DAT-20199
     secrets: inherit
     with:
       dry_run: true
@@ -63,7 +63,7 @@ jobs:
       deployToMavenCentral: false
 
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: always()
     needs: [dry-run-get-draft-release, dry-run-release-published]
     permissions:
@@ -104,7 +104,7 @@ jobs:
 
   notify:
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs:
       [
         dry-run-attach-artifact-to-release,

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, labeled, unlabeled, synchronize, reopened]
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@DAT-20199
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,16 @@ permissions:
 jobs:
   authorize:
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - run: true
 
   build-test:
     needs: authorize
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@DAT-20199
     secrets: inherit
 
   dependabot:
     needs: build-test
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@DAT-20199
     secrets: inherit


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use a specific branch (`DAT-20199`) instead of `main` for the referenced workflow files and changes the runner environment from `ubuntu-latest` to `ubuntu-24.04-arm` across multiple workflows. These updates ensure consistency in workflow execution and align the environment with the desired architecture.

### Workflow Reference Updates:
* [`.github/workflows/attach-artifact-release.yml`](diffhunk://#diff-4e6cdd9dccb26ce28aa3716a4046b99dd39c69e9319bf6b4e2922e6309c13b4aL18-R18): Updated the referenced workflow file to use the `DAT-20199` branch.
* [`.github/workflows/build-nightly.yml`](diffhunk://#diff-9af00ec87e110684f20ae5b6b3bd168ad21793f9dfe9946c9c48587fdd6ef1f6L16-R16): Changed the referenced workflow file to point to the `DAT-20199` branch.
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L21-R21): Updated the referenced workflow file to use `DAT-20199`.
* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L19-R19): Switched the referenced workflow file to the `DAT-20199` branch.
* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL17-R25): Updated multiple job references to use the `DAT-20199` branch. [[1]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL17-R25) [[2]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL57-R57) [[3]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL16-R16)

### Runner Environment Updates:
* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL17-R25): Changed the runner environment from `ubuntu-latest` to `ubuntu-24.04-arm` for several jobs (`dry-run-get-draft-release`, `cleanup`, and `notify`). [[1]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL17-R25) [[2]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL66-R66) [[3]](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL107-R107)
* [`.github/workflows/label-pr.yml`](diffhunk://#diff-0db60427798e4c073e17fdc3766b6053af5e91e45302619b21167442b16c0e47L7-R7): Updated the runner environment to `ubuntu-24.04-arm`.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R29): Changed the runner environment to `ubuntu-24.04-arm` for multiple jobs and updated the workflow references to use the `DAT-20199` branch.