### PR TITLE
ci: restrict test matrix to ubuntu-latest

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -17,4 +17,5 @@ jobs:
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     with:
       nightly: true
+      os: '["ubuntu-latest"]'
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
   build-test:
     needs: authorize
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
+    with:
+      os: '["ubuntu-latest"]'
     secrets: inherit
 
   dependabot:


### PR DESCRIPTION
## Summary

- Override the `os` input on the reusable `os-extension-test.yml` workflow to `["ubuntu-latest"]` in both `test.yml` and `build-nightly.yml`.
- Restores the configuration that existed before `test.yml` was rewritten in the v5.0.0 series, when the default matrix `["ubuntu-latest", "windows-latest"]` started getting applied implicitly.

## Why

Every test in this repo extends `BaseTestCase`, which spins up a Linux Oracle XE image via testcontainers (`gvenzl/oracle-xe:21-slim-faststart`). GitHub-hosted `windows-latest` runners don't include a Linux Docker engine, so `testcontainers` throws `Could not find a valid Docker environment` on every Windows shard. This has been failing on `main` and on every dependabot PR for ~12 months; the only reason no one's complained is that `Build & Package` runs on ubuntu and ships a valid OS-agnostic jar.

## Test plan

- [ ] Verify the `Build and Test` workflow on this PR no longer runs Windows shards
- [ ] Verify Linux Java 17 / 21 / 25 jobs still run and pass
- [ ] After merge, confirm the nightly cron run is green